### PR TITLE
feat: support pagination for /classify/videos

### DIFF
--- a/examples/classify.ts
+++ b/examples/classify.ts
@@ -118,6 +118,17 @@ const CLASSES = [
     });
   });
 
+  let nextIndexPage = await resultIndex.next();
+  while (nextIndexPage !== null) {
+    nextIndexPage.forEach((data) => {
+      console.log(`video_id=${data.videoId}`);
+      data.classes.forEach((cl) => {
+        console.log(`  name=${cl.name} score=${cl.score} durationRatio=${cl.durationRatio}`);
+      });
+    });
+    nextIndexPage = await resultIndex.next();
+  }
+
   console.log('Classify by videos');
   const resultVideos = await client.classify.videos({
     videoIds: videoIds,
@@ -131,4 +142,15 @@ const CLASSES = [
       console.log(`  name=${cl.name} score=${cl.score} durationRatio=${cl.durationRatio}`);
     });
   });
+
+  let nextVideosPage = await resultVideos.next();
+  while (nextVideosPage !== null) {
+    nextVideosPage.forEach((data) => {
+      console.log(`video_id=${data.videoId}`);
+      data.classes.forEach((cl) => {
+        console.log(`  name=${cl.name} score=${cl.score} durationRatio=${cl.durationRatio}`);
+      });
+    });
+    nextVideosPage = await resultVideos.next();
+  }
 })();

--- a/src/models/classify/index.ts
+++ b/src/models/classify/index.ts
@@ -1,17 +1,6 @@
 import * as Resources from '../../resources';
 import { TokenPageInfo } from '../interfaces';
 
-export interface ClassifyResultResponse {
-  data: ClassifyVideoData[];
-}
-
-export class ClassifyResult {
-  data: ClassifyVideoData[];
-  constructor(data: ClassifyResultResponse) {
-    this.data = data.data;
-  }
-}
-
 export interface ClassifyPageResultResponse {
   data: ClassifyVideoData[];
   pageInfo: TokenPageInfo;

--- a/src/resources/classify/index.ts
+++ b/src/resources/classify/index.ts
@@ -8,17 +8,17 @@ export class Classify extends APIResource {
   async videos(
     { conversationOption = 'semantic', ...restBody }: ClassifyVideosOptions,
     options: RequestOptions = {},
-  ): Promise<Models.ClassifyResult> {
+  ): Promise<Models.ClassifyPageResult> {
     const _body = convertKeysToSnakeCase({
       ...restBody,
       conversationOption,
     });
-    const res = await this._post<Models.ClassifyResultResponse>(
+    const res = await this._post<Models.ClassifyPageResultResponse>(
       'classify',
       removeUndefinedValues(_body),
       options,
     );
-    return new Models.ClassifyResult(res);
+    return new Models.ClassifyPageResult(this, res);
   }
 
   async index(


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

The search API has been updated to support both text and image queries. It call the `search-v2` endpoint instead.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

The query is now divided into text and image. Since the existing query parameter was a mandatory parameter, it has been changed from mandatory to optional and deprecated, allowing the use of either query_text, query_image_file, or query_image_url as parameters.

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).
