### PR TITLE
Relocate `detailedScores` into `ClassifyClass`

### DIFF
--- a/src/models/classify/index.ts
+++ b/src/models/classify/index.ts
@@ -40,8 +40,7 @@ export interface ClassifyClip {
   score: number;
   option: string;
   prompt: string;
-  thumbnail_url?: string;
-  detailed_scores?: ClassifyDetailedScore;
+  thumbnailUrl?: string;
 }
 
 export interface ClassifyClass {
@@ -49,6 +48,7 @@ export interface ClassifyClass {
   score: number;
   durationRatio: number;
   clips?: ClassifyClip[];
+  detailedScores?: ClassifyDetailedScore;
 }
 
 export interface ClassifyVideoData {


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

Relocated `detailed_scores` field into `ClassifyClass`.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).