### PR TITLE
feat: add stream processing and support in open-ended text

### DIFF
--- a/examples/generate.ts
+++ b/examples/generate.ts
@@ -3,19 +3,22 @@ import { TwelveLabs } from 'twelvelabs';
 (async () => {
   const client = new TwelveLabs({ apiKey: process.env.API_KEY });
 
-  const index = await client.index.retrieve('<YOUR_INDEX_ID>');
-  const videos = await client.index.video.list(index.id);
-  if (videos.length === 0) {
-    throw new Error(`No videos in index ${index.id}, exit`);
-  }
-  const [video] = videos;
+  const videoId = '<YOUR_VIDEO_ID>';
 
-  const gist = await client.generate.gist(video.id, ['title']);
+  const gist = await client.generate.gist(videoId, ['title']);
   console.log(`Gist: title=${gist.title} topics=${gist.topics} hashtags=${gist.hashtags}`);
 
-  const summary = await client.generate.summarize(video.id, 'summary');
+  const summary = await client.generate.summarize(videoId, 'summary');
   console.log(`Summary: ${summary.summary}`);
 
-  const text = await client.generate.text(video.id, 'What happened?');
+  const text = await client.generate.text(videoId, 'What happened?');
   console.log(`Open-ended Text: ${text.data}`);
+
+  const textStream = await client.generate.textStream({ videoId, prompt: 'What happened?' });
+
+  for await (const text of textStream) {
+    console.log(text);
+  }
+
+  console.log(`Aggregated text: ${textStream.aggregatedText}`);
 })();

--- a/src/core.ts
+++ b/src/core.ts
@@ -58,9 +58,12 @@ export class APIClient {
     try {
       const response = await fetch(url, config);
       const contentType = response.headers.get('Content-Type');
+      const transferEncoding = response.headers.get('Transfer-Encoding');
       let body = null;
 
-      if (contentType && contentType.includes('application/json')) {
+      if (transferEncoding === 'chunked') {
+        body = response.body;
+      } else if (contentType && contentType.includes('application/json')) {
         const rawBody = await response.json();
         body = convertKeysToCamelCase(rawBody, skipCamelKeys);
       } else {

--- a/src/models/generate/index.ts
+++ b/src/models/generate/index.ts
@@ -30,3 +30,64 @@ export interface GenerateGistResult {
   topics?: string[];
   hashtags?: string[];
 }
+
+export class GenerateTextStreamResult {
+  id: string;
+  texts: string[] = [];
+  aggregatedText: string = '';
+  private stream: ReadableStream;
+
+  constructor(stream: ReadableStream) {
+    this.stream = stream;
+    this.id = '';
+  }
+
+  async *[Symbol.asyncIterator]() {
+    const reader = this.stream.getReader();
+    const decoder = new TextDecoder('utf-8');
+    let chunk = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        // Decode the current chunk and concatenate it to the previous chunks
+        chunk += decoder.decode(value, { stream: true });
+        const lines = chunk.split('\n');
+        // Store the last incomplete line back into chunk
+        chunk = lines.pop()!;
+
+        for (const line of lines) {
+          if (!line) continue;
+          const event = JSON.parse(line);
+
+          switch (event.event_type) {
+            case 'stream_start':
+              this.id = event.metadata?.generation_id || '';
+              break;
+            case 'stream_error':
+              throw new Error(event.error.message);
+            case 'text_generation':
+              this.texts.push(event.text);
+              this.aggregatedText += event.text;
+              yield event.text;
+              break;
+            case 'stream_end':
+            default:
+              break;
+          }
+        }
+      }
+    }
+
+    // Process any remaining chunk that wasn't completed in the loop
+    if (chunk) {
+      const event = JSON.parse(chunk);
+      if (event.event_type === 'text_generation') {
+        this.texts.push(event.text);
+        this.aggregatedText += event.text;
+        yield event.text;
+      }
+    }
+  }
+}

--- a/src/resources/generate/index.ts
+++ b/src/resources/generate/index.ts
@@ -73,6 +73,6 @@ export class Generate extends APIResource {
       removeUndefinedValues(_body),
       options,
     );
-    return new Models.GenerateTextStreamResult(trackStream(res, 32 * 1024));
+    return new Models.GenerateTextStreamResult(trackStream(res));
   }
 }

--- a/src/resources/generate/index.ts
+++ b/src/resources/generate/index.ts
@@ -1,8 +1,8 @@
 import { RequestOptions } from '../../core';
 import * as Models from '../../models';
 import { APIResource } from '../../resource';
-import { convertKeysToSnakeCase, removeUndefinedValues } from '../../util';
-import { GenerateGistType, GenerateSummarizeType } from './interfaces';
+import { convertKeysToSnakeCase, removeUndefinedValues, trackStream } from '../../util';
+import { GenerateGistType, GenerateSummarizeType, GenerateTextStreamParams } from './interfaces';
 
 export class Generate extends APIResource {
   async gist(
@@ -50,7 +50,29 @@ export class Generate extends APIResource {
       prompt,
       temperature,
     });
-    const res = await this._post<Models.GenerateOpenEndedTextResult>('generate', _body, options);
+    const res = await this._post<Models.GenerateOpenEndedTextResult>(
+      'generate',
+      removeUndefinedValues(_body),
+      options,
+    );
     return res;
+  }
+
+  async textStream(
+    { videoId, prompt, temperature }: GenerateTextStreamParams,
+    options: RequestOptions = {},
+  ): Promise<Models.GenerateTextStreamResult> {
+    const _body = convertKeysToSnakeCase({
+      videoId,
+      prompt,
+      temperature,
+      stream: true,
+    });
+    const res = await this._post<AsyncIterable<Uint8Array>>(
+      'generate',
+      removeUndefinedValues(_body),
+      options,
+    );
+    return new Models.GenerateTextStreamResult(trackStream(res, 64 * 1024));
   }
 }

--- a/src/resources/generate/index.ts
+++ b/src/resources/generate/index.ts
@@ -73,6 +73,6 @@ export class Generate extends APIResource {
       removeUndefinedValues(_body),
       options,
     );
-    return new Models.GenerateTextStreamResult(trackStream(res, 64 * 1024));
+    return new Models.GenerateTextStreamResult(trackStream(res, 32 * 1024));
   }
 }

--- a/src/resources/generate/interfaces.ts
+++ b/src/resources/generate/interfaces.ts
@@ -1,2 +1,8 @@
 export type GenerateGistType = 'topic' | 'hashtag' | 'title';
 export type GenerateSummarizeType = 'summary' | 'chapter' | 'highlight';
+
+export interface GenerateTextStreamParams {
+  videoId: string;
+  prompt: string;
+  temperature?: number;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -146,7 +146,9 @@ const readBytes = async function* (iterable: AsyncIterable<Uint8Array>, chunkSiz
 };
 
 // Tracks the stream and processes it in smaller chunks.
-export const trackStream = (stream: AsyncIterable<Uint8Array>, chunkSize: number) => {
+// The default chunk size is set to 32KB (32 * 1024 bytes). This chunk size is chosen
+// to balance between memory usage and processing efficiency.
+export const trackStream = (stream: AsyncIterable<Uint8Array>, chunkSize: number = 32 * 1024) => {
   const iterator = readBytes(stream, chunkSize);
 
   return new ReadableStream<Uint8Array>({


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

This change handles streaming responses from API responses with Transfer-Encoding=chunked and supports them in open-ended text generation.

Returning two different types from a single method can lead to unnecessary tricky code, such as the use of type aliases. Therefore, I have separated this functionality into a distinct `textStream` method.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).

## Further comments

Testing completed
<img width="725" alt="image" src="https://github.com/twelvelabs-io/twelvelabs-js/assets/155519863/5c5dc857-f88e-49aa-9885-3fdd83935f30">
<img width="1416" alt="image" src="https://github.com/twelvelabs-io/twelvelabs-js/assets/155519863/ac4b67f7-b7cf-45e4-ad46-743b8788311b">

