### PR TITLE
fix: boolean params in form data

### DIFF
--- a/src/resources/task/index.ts
+++ b/src/resources/task/index.ts
@@ -63,7 +63,7 @@ export class Task extends APIResource {
     if (body.url) formData.append('video_url', body.url);
     if (body.transcriptionUrl) formData.append('transcription_url', body.transcriptionUrl);
     if (body.language) formData.append('language', body.language);
-    if (body.disableVideoStream) formData.append('disable_video_stream', body.disableVideoStream);
+    if (body.disableVideoStream) formData.append('disable_video_stream', String(body.disableVideoStream));
 
     try {
       if (body.file) attachFormFile(formData, 'video_file', body.file);


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

fixed `ERR_INVALID_ARG_TYPE` error when using boolean params `disableVideoStream`
and checked all boolean params used for form data request, there's only this params.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).

## Further comments

<!-- If there's anything else you'd like to add about the pull request, put it here. -->
