### PR TITLE
feat: handle stream response by request params `stream`

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -55,13 +55,14 @@ export class APIClient {
         : undefined,
     };
 
+    const isStreamRequest = (params && params.stream === true) || (body && (body as any).stream === true);
+
     try {
       const response = await fetch(url, config);
       const contentType = response.headers.get('Content-Type');
-      const transferEncoding = response.headers.get('Transfer-Encoding');
       let body = null;
 
-      if (transferEncoding === 'chunked') {
+      if (isStreamRequest) {
         body = response.body;
       } else if (contentType && contentType.includes('application/json')) {
         const rawBody = await response.json();


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

use request params to identify whether response should be handled by streaming encoding.
now we're not going to use `Transfer-Encoding` of response header.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).

## Test done

- Generate (stream) API - working well with streaming handler

![image](https://github.com/user-attachments/assets/327348c5-f665-4876-9ddb-22ae2bc9a14b)

- Embed API - working well even when response header contains `Transfer-Encoding=chunked`

![image](https://github.com/user-attachments/assets/95e2a144-228c-4982-ab01-a71a877fae9c)
![image](https://github.com/user-attachments/assets/7bdafa07-2019-4079-98e3-03aba69b5a87)
