### PR TITLE
fix: embed option is optional

### DIFF
--- a/src/resources/video/index.ts
+++ b/src/resources/video/index.ts
@@ -8,7 +8,7 @@ export class Video extends APIResource {
   async retrieve(
     indexId: string,
     id: string,
-    { embed }: RetrieveVideoParams,
+    { embed }: RetrieveVideoParams = {},
     options: RequestOptions = {},
   ): Promise<Models.Video> {
     const _params = convertKeysToSnakeCase({ embed });


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

`RetrieveVideoParams` should be optional; changed to optional params

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).
