### PR TITLE
fix: generate non-stream

### DIFF
--- a/src/resources/generate/index.ts
+++ b/src/resources/generate/index.ts
@@ -36,6 +36,7 @@ export class Generate extends APIResource {
       videoId,
       prompt,
       temperature,
+      stream: false,
     });
     const res = await this._post<Models.GenerateOpenEndedTextResult>(
       'generate',


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

Since we've already separated /generate endpoint with `textStream` and `text`, so we should add `stream: false` to `text` method params.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).

## Further comments

Test done. (results of `text` and `textStream`)
<img width="655" alt="image" src="https://github.com/user-attachments/assets/5d6c9a98-1246-4149-894b-5bc272e64aee">

