### PR TITLE
fix: missing hls field in Task model

### DIFF
--- a/src/models/task/index.ts
+++ b/src/models/task/index.ts
@@ -8,6 +8,7 @@ export interface TaskResponse {
   videoId?: string[];
   status: string;
   systemMetadata: Record<string, any>;
+  hls?: TaskHLS;
   createdAt: string;
   updatedAt?: string;
 }
@@ -30,6 +31,7 @@ export class Task {
     this.videoId = data.videoId;
     this.status = data.status;
     this.systemMetadata = data.systemMetadata;
+    this.hls = data.hls;
     this.createdAt = data.createdAt;
     this.updatedAt = data.updatedAt;
   }
@@ -115,7 +117,7 @@ export interface TaskHLS {
   videoUrl?: string;
   thumbnailUrls?: string[];
   status?: string;
-  updatedAt: string;
+  updatedAt?: string;
 }
 
 export interface TransferImportVideo {


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

this PR resolves [this issue](https://github.com/twelvelabs-io/twelvelabs-js/issues/61) raised by user. missing `hls` field is added to `TaskResponse` and `Task` interface.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).
