### PR TITLE
fix: camel/snake case handling in video fields

### DIFF
--- a/src/resources/index/index.ts
+++ b/src/resources/index/index.ts
@@ -28,8 +28,8 @@ export class Index extends APIResource {
       _id: id,
       indexName: name,
     });
-    handleComparisonParams(_params, 'createdAt', createdAt);
-    handleComparisonParams(_params, 'updatedAt', updatedAt);
+    handleComparisonParams(_params, 'created_at', createdAt);
+    handleComparisonParams(_params, 'updated_at', updatedAt);
     const res = await this._get<{ data: Models.IndexResponse[] }>(
       'indexes',
       removeUndefinedValues(_params),
@@ -48,8 +48,8 @@ export class Index extends APIResource {
       _id: id,
       indexName: name,
     });
-    handleComparisonParams(_params, 'createdAt', createdAt);
-    handleComparisonParams(_params, 'updatedAt', updatedAt);
+    handleComparisonParams(_params, 'created_at', createdAt);
+    handleComparisonParams(_params, 'updated_at', updatedAt);
     const res = await this._get<{ data: Models.IndexResponse[]; pageInfo: Models.PageInfo }>(
       'indexes',
       removeUndefinedValues(_params),

--- a/src/resources/task/index.ts
+++ b/src/resources/task/index.ts
@@ -67,8 +67,8 @@ export class Task extends APIResource {
     options: RequestOptions = {},
   ): Promise<Models.Task[]> {
     const _params = convertKeysToSnakeCase(restParams);
-    handleComparisonParams(_params, 'createdAt', createdAt);
-    handleComparisonParams(_params, 'updatedAt', updatedAt);
+    handleComparisonParams(_params, 'created_at', createdAt);
+    handleComparisonParams(_params, 'updated_at', updatedAt);
     const res = await this._get<{ data: Models.TaskResponse[] }>(
       'tasks',
       removeUndefinedValues(_params),
@@ -83,8 +83,8 @@ export class Task extends APIResource {
   ): Promise<Models.TaskListWithPagination> {
     const originParams = { createdAt, updatedAt, ...restParams };
     const _params = convertKeysToSnakeCase(restParams);
-    handleComparisonParams(_params, 'createdAt', createdAt);
-    handleComparisonParams(_params, 'updatedAt', updatedAt);
+    handleComparisonParams(_params, 'created_at', createdAt);
+    handleComparisonParams(_params, 'updated_at', updatedAt);
     const res = await this._get<{ data: Models.TaskResponse[]; pageInfo: Models.PageInfo }>(
       'tasks',
       removeUndefinedValues(_params),

--- a/src/resources/video/index.ts
+++ b/src/resources/video/index.ts
@@ -15,7 +15,7 @@ export class Video extends APIResource {
     const res = await this._get<Models.VideoResponse>(
       `indexes/${indexId}/videos/${id}`,
       removeUndefinedValues(_params),
-      { ...options, skipCamelKeys: ['metadata'] },
+      { ...options, skipCamelKeys: ['user_metadata'] },
     );
     return new Models.Video(this, indexId, res);
   }
@@ -31,8 +31,8 @@ export class Video extends APIResource {
     handleComparisonParams(_params, 'height', height);
     handleComparisonParams(_params, 'duration', duration);
     handleComparisonParams(_params, 'fps', fps);
-    handleComparisonParams(_params, 'createdAt', createdAt);
-    handleComparisonParams(_params, 'updatedAt', updatedAt);
+    handleComparisonParams(_params, 'created_at', createdAt);
+    handleComparisonParams(_params, 'updated_at', updatedAt);
     const res = await this._get<{ data: Models.VideoResponse[] }>(
       `indexes/${indexId}/videos`,
       removeUndefinedValues(_params),
@@ -62,8 +62,8 @@ export class Video extends APIResource {
     handleComparisonParams(_params, 'height', height);
     handleComparisonParams(_params, 'duration', duration);
     handleComparisonParams(_params, 'fps', fps);
-    handleComparisonParams(_params, 'createdAt', createdAt);
-    handleComparisonParams(_params, 'updatedAt', updatedAt);
+    handleComparisonParams(_params, 'created_at', createdAt);
+    handleComparisonParams(_params, 'updated_at', updatedAt);
     const res = await this._get<{ data: Models.VideoResponse[]; pageInfo: Models.PageInfo }>(
       `indexes/${indexId}/videos`,
       removeUndefinedValues(_params),
@@ -80,7 +80,7 @@ export class Video extends APIResource {
   ): Promise<void> {
     await this._put<void>(
       `indexes/${indexId}/videos/${id}`,
-      removeUndefinedValues(convertKeysToSnakeCase({ userMetadata })),
+      removeUndefinedValues({ user_metadata: userMetadata }),
       options,
     );
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,9 +28,13 @@ export function convertKeysToCamelCase(obj: any, skipKeys?: string[]): any {
     return obj.map((v) => convertKeysToCamelCase(v));
   } else if (obj !== null && obj.constructor === Object) {
     return Object.keys(obj).reduce((result, key) => {
-      // Skip converting keys by `skipKeys`
+      // if `skipKeys` is provided, skip converting inner values of keys in `skipKeys`
+      // only convert the keys in `skipKeys` like `user_metadata` to `userMetadata`
       if (skipKeys?.includes(key)) {
-        return { ...result, [key]: obj[key] };
+        const camelCaseKey = key.replace(/([-_][a-z])/g, (group) =>
+          group.toUpperCase().replace('-', '').replace('_', ''),
+        );
+        return { ...result, [camelCaseKey]: obj[key] };
       }
       // Check if key starts with "_"
       if (key.startsWith('_')) {


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

1. The JS SDK automatically converts all request/response keys to snake case and camel case, respectively. This is for the convenience of [typical JavaScript users](https://rigaux.org/language-study/syntax-across-languages.html#VrsTkns). However, user metadata should be excluded from this case conversion since it consists of values set directly by the user.
2. While working on this task, I also addressed an issue where parameters used for filtering, such as created_at, were not being converted to snake case properly, causing filters to fail.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).

## Further comments

Test done by this code:

```ts
const index = await client.index.retrieve('INDEX_ID');

console.log(`Videos in index id=${index.id}`);
const videos = await client.index.video.list(index.id, { createdAt: '2025-03-06T06:10:10Z' });
if (videos.length === 0) {
  console.log('No videos in the index, exiting');
  return;
}
videos.forEach((video) => {
  console.log('userMetadata', video.userMetadata);
});

await client.index.video.update(index.id, videos[0].id, {
  userMetadata: { from_sdk: true, test_snake: 1, testCamel: 1 },
});
const video = await client.index.video.retrieve(index.id, videos[0].id);
console.log(`Updated first video's metadata`, video.userMetadata);
```

![image](https://github.com/user-attachments/assets/ef6f3eef-bbb3-4fd2-9837-9f90c76e6f34)
