### PR TITLE
fix: determine stream request

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -36,6 +36,10 @@ export class APIClient {
       ...options.headers,
     };
 
+    const isParamsStream = params && params.stream === true;
+    const isBodyStream = body && (body as any).stream === true;
+    const isStreamRequest = isParamsStream || isBodyStream;
+
     // Bun will natively append headers like Content-Type, Content-Length, etc. so doesn't need to set them manually.
     if (!isBunEnv() && body) {
       if (body instanceof FormData) {
@@ -57,8 +61,6 @@ export class APIClient {
       headers,
       body,
     };
-
-    const isStreamRequest = (params && params.stream === true) || (body && (body as any).stream === true);
 
     try {
       const response = await fetch(url, config);


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

<!-- Please provide a detailed description of the pull request, including the purpose of the change, the problem it solves, or the feature it adds to the project. Ensure you link any relevant issues this PR addresses. -->

We do stringify body before determining `isStreamRequest`, so it handles stream response as normal json response and throws parsing error. Fixed determining order.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).
