### PR TITLE
feat: support multi-vector for embedding retrieval api

### DIFF
--- a/examples/embed.ts
+++ b/examples/embed.ts
@@ -8,7 +8,7 @@ import { TwelveLabs, EmbeddingsTask, SegmentEmbedding } from 'twelvelabs';
   const printSegments = (segments: SegmentEmbedding[]) => {
     segments.forEach((segment) => {
       console.log(
-        `embeddingScope=${segment.embeddingScope} startOffsetSec=${segment.startOffsetSec} endOffsetSec=${segment.endOffsetSec}`,
+        `embeddingScope=${segment.embeddingScope} embeddingOption=${segment.embeddingOption} startOffsetSec=${segment.startOffsetSec} endOffsetSec=${segment.endOffsetSec}`,
       );
       console.log('embeddings: ', segment.embeddingsFloat);
     });
@@ -64,7 +64,7 @@ import { TwelveLabs, EmbeddingsTask, SegmentEmbedding } from 'twelvelabs';
   });
   console.log(`Embedding done: ${status}`);
 
-  task = await task.retrieve();
+  task = await task.retrieve({ embeddingOption: ['visual-text', 'audio'] });
   if (task.videoEmbedding) {
     if (task.videoEmbedding.segments) {
       printSegments(task.videoEmbedding.segments);

--- a/examples/video.ts
+++ b/examples/video.ts
@@ -1,4 +1,4 @@
-import { TwelveLabs, Video } from 'twelvelabs';
+import { TwelveLabs, Video, SegmentEmbedding } from 'twelvelabs';
 
 (async () => {
   const client = new TwelveLabs({ apiKey: process.env.API_KEY });
@@ -33,5 +33,35 @@ import { TwelveLabs, Video } from 'twelvelabs';
     nextPageData.forEach((video: Video) => {
       console.log(`  filename=${video.systemMetadata.filename} duration=${video.systemMetadata.duration}`);
     });
+  }
+
+  // Example of retrieving video with embeddings using embedding_option
+  console.log('\nRetrieving video with embeddings:');
+  const videoWithEmbeddings = await client.index.video.retrieve(index.id, videos[0].id, {
+    embeddingOption: ['visual-text', 'audio']
+  });
+
+  if (videoWithEmbeddings.embedding) {
+    console.log(`Retrieved embeddings for video: ${videoWithEmbeddings.id}`);
+    const printEmbeddings = (segments: SegmentEmbedding[]) => {
+      segments.forEach((segment) => {
+        // Print embedding info and first few values of the embeddings
+        const truncatedEmbeddings = segment.embeddingsFloat ?
+          segment.embeddingsFloat.slice(0, 5).map(v => v.toFixed(4)) : [];
+
+        console.log(`  Segment: startTime=${segment.startOffsetSec}s endTime=${segment.endOffsetSec}s`);
+        console.log(`  Scope: ${segment.embeddingScope}, Option: ${segment.embeddingOption}`);
+        console.log(`  Embeddings (truncated): [${truncatedEmbeddings.join(', ')}...]`);
+        console.log(`  Total embedding values: ${segment.embeddingsFloat?.length || 0}`);
+        console.log('---');
+      });
+    };
+
+    if (videoWithEmbeddings.embedding.videoEmbedding?.segments) {
+      console.log('Video embeddings:');
+      printEmbeddings(videoWithEmbeddings.embedding.videoEmbedding.segments);
+    }
+  } else {
+    console.log('No embeddings found for the video');
   }
 })();

--- a/src/core.ts
+++ b/src/core.ts
@@ -28,7 +28,14 @@ export class APIClient {
   ): Promise<any> {
     const url = new URL(endpoint, this.baseUrl);
     if (params) {
-      Object.keys(params).forEach((key) => url.searchParams.append(key, params![key]));
+      Object.keys(params).forEach((key) => {
+        const value = params![key];
+        if (Array.isArray(value)) {
+          value.forEach((item) => url.searchParams.append(key, item));
+        } else {
+          url.searchParams.append(key, value);
+        }
+      });
     }
 
     let headers = {

--- a/src/models/embed/index.ts
+++ b/src/models/embed/index.ts
@@ -33,6 +33,7 @@ export interface SegmentEmbeddingResponse {
   startOffsetSec?: number;
   endOffsetSec?: number;
   embeddingScope?: string;
+  embeddingOption?: string;
 }
 
 export class SegmentEmbedding {
@@ -40,12 +41,14 @@ export class SegmentEmbedding {
   startOffsetSec?: number;
   endOffsetSec?: number;
   embeddingScope?: string;
+  embeddingOption?: string;
 
   constructor(data: SegmentEmbeddingResponse) {
     this.embeddingsFloat = data.float;
     this.startOffsetSec = data.startOffsetSec;
     this.endOffsetSec = data.endOffsetSec;
     this.embeddingScope = data.embeddingScope;
+    this.embeddingOption = data.embeddingOption;
   }
 }
 
@@ -119,8 +122,8 @@ export class EmbeddingsTask {
     this.createdAt = data.createdAt;
   }
 
-  async retrieve(options: RequestOptions = {}): Promise<EmbeddingsTask> {
-    return await this._resource.retrieve(this.id, options);
+  async retrieve(params: Resources.RetrieveEmbeddingsTaskParams = {}, options: RequestOptions = {}): Promise<EmbeddingsTask> {
+    return await this._resource.retrieve(this.id, params, options);
   }
 
   async getStatus(options: RequestOptions = {}): Promise<string> {

--- a/src/resources/embed/index.ts
+++ b/src/resources/embed/index.ts
@@ -12,21 +12,18 @@ export class EmbedTask extends APIResource {
     params: RetrieveEmbeddingsTaskParams = {},
     options: RequestOptions = {}
   ): Promise<Models.EmbeddingsTask> {
-    let queryString = '';
+    const { embeddingOption } = params;
 
-    if (params.embeddingOption && params.embeddingOption.length > 0) {
-      params.embeddingOption.forEach(option => {
-        queryString += `embedding_option=${encodeURIComponent(option)}&`;
+    let url = `embed/tasks/${id}`;
+    if (embeddingOption?.length) {
+      const queryParams = new URLSearchParams();
+      embeddingOption.forEach(option => {
+        queryParams.append('embedding_option', option);
       });
-      // Remove trailing &
-      queryString = queryString.slice(0, -1);
+      url += `?${queryParams.toString()}`;
     }
 
-    const res = await this._get<Models.EmbeddingsTaskResponse>(
-      `embed/tasks/${id}${queryString ? '?' + queryString : ''}`,
-      {},
-      options
-    );
+    const res = await this._get<Models.EmbeddingsTaskResponse>(url, {}, options);
     return new Models.EmbeddingsTask(this, res);
   }
 

--- a/src/resources/embed/index.ts
+++ b/src/resources/embed/index.ts
@@ -14,15 +14,14 @@ export class EmbedTask extends APIResource {
   ): Promise<Models.EmbeddingsTask> {
     const { embeddingOption } = params;
 
-    const url = new URL(`embed/tasks/${id}`, this.baseUrl);
+    const path = `embed/tasks/${id}`;
+    const queryParams = embeddingOption?.length ? { embedding_option: embeddingOption } : undefined;
 
-    if (embeddingOption?.length) {
-      embeddingOption.forEach(option => {
-        url.searchParams.append('embedding_option', option);
-      });
-    }
-
-    const res = await this._get<Models.EmbeddingsTaskResponse>(url.toString(), {}, options);
+    const res = await this._get<Models.EmbeddingsTaskResponse>(
+      path,
+      queryParams,
+      options
+    );
     return new Models.EmbeddingsTask(this, res);
   }
 

--- a/src/resources/embed/index.ts
+++ b/src/resources/embed/index.ts
@@ -3,12 +3,30 @@ import { RequestOptions } from '../../core';
 import * as Models from '../../models';
 import { APIResource } from '../../resource';
 import { TwelveLabs } from '../..';
-import { CreateEmbedParams, CreateEmbeddingsTaskVideoParams, ListEmbeddingsTaskParams } from './interfaces';
+import { CreateEmbedParams, CreateEmbeddingsTaskVideoParams, ListEmbeddingsTaskParams, RetrieveEmbeddingsTaskParams } from './interfaces';
 import { attachFormFile, removeUndefinedValues, convertKeysToSnakeCase } from '../../util';
 
 export class EmbedTask extends APIResource {
-  async retrieve(id: string, options: RequestOptions = {}): Promise<Models.EmbeddingsTask> {
-    const res = await this._get<Models.EmbeddingsTaskResponse>(`embed/tasks/${id}`, {}, options);
+  async retrieve(
+    id: string,
+    params: RetrieveEmbeddingsTaskParams = {},
+    options: RequestOptions = {}
+  ): Promise<Models.EmbeddingsTask> {
+    let queryString = '';
+
+    if (params.embeddingOption && params.embeddingOption.length > 0) {
+      params.embeddingOption.forEach(option => {
+        queryString += `embedding_option=${encodeURIComponent(option)}&`;
+      });
+      // Remove trailing &
+      queryString = queryString.slice(0, -1);
+    }
+
+    const res = await this._get<Models.EmbeddingsTaskResponse>(
+      `embed/tasks/${id}${queryString ? '?' + queryString : ''}`,
+      {},
+      options
+    );
     return new Models.EmbeddingsTask(this, res);
   }
 

--- a/src/resources/embed/index.ts
+++ b/src/resources/embed/index.ts
@@ -14,16 +14,15 @@ export class EmbedTask extends APIResource {
   ): Promise<Models.EmbeddingsTask> {
     const { embeddingOption } = params;
 
-    let url = `embed/tasks/${id}`;
+    const url = new URL(`embed/tasks/${id}`, this.baseUrl);
+
     if (embeddingOption?.length) {
-      const queryParams = new URLSearchParams();
       embeddingOption.forEach(option => {
-        queryParams.append('embedding_option', option);
+        url.searchParams.append('embedding_option', option);
       });
-      url += `?${queryParams.toString()}`;
     }
 
-    const res = await this._get<Models.EmbeddingsTaskResponse>(url, {}, options);
+    const res = await this._get<Models.EmbeddingsTaskResponse>(url.toString(), {}, options);
     return new Models.EmbeddingsTask(this, res);
   }
 

--- a/src/resources/embed/interfaces.ts
+++ b/src/resources/embed/interfaces.ts
@@ -30,5 +30,5 @@ export interface ListEmbeddingsTaskParams extends PageOptions {
 }
 
 export interface RetrieveEmbeddingsTaskParams {
-  embeddingOption?: Array<'visual-text' | 'audio'>;
+  embeddingOption?: ('visual-text' | 'audio')[];
 }

--- a/src/resources/embed/interfaces.ts
+++ b/src/resources/embed/interfaces.ts
@@ -28,3 +28,7 @@ export interface ListEmbeddingsTaskParams extends PageOptions {
   endedAt?: string;
   status?: 'processing' | 'ready' | 'failed';
 }
+
+export interface RetrieveEmbeddingsTaskParams {
+  embeddingOption?: Array<'visual-text' | 'audio'>;
+}

--- a/src/resources/task/index.ts
+++ b/src/resources/task/index.ts
@@ -102,18 +102,10 @@ export class Task extends APIResource {
 
     formData.append('index_id', body.indexId);
     if (body.url) formData.append('video_url', body.url);
-    if (body.transcriptionUrl) {
-      formData.append('transcription_url', body.transcriptionUrl);
-      formData.append('provide_transcription', true);
-    }
     if (body.enableVideoStream) formData.append('enable_video_stream', String(body.enableVideoStream));
 
     try {
       if (body.file) attachFormFile(formData, 'video_file', body.file);
-      if (body.transcriptionFile) {
-        attachFormFile(formData, 'transcription_file', body.transcriptionFile);
-        formData.append('provide_transcription', 'true');
-      }
     } catch (err) {
       throw err;
     }

--- a/src/resources/task/interfaces.ts
+++ b/src/resources/task/interfaces.ts
@@ -14,8 +14,6 @@ export interface CreateTaskParams {
   indexId: string;
   file?: Buffer | NodeJS.ReadableStream | string;
   url?: string;
-  transcriptionFile?: Buffer | NodeJS.ReadableStream | string;
-  transcriptionUrl?: string;
   enableVideoStream?: boolean;
 }
 

--- a/src/resources/video/index.ts
+++ b/src/resources/video/index.ts
@@ -11,18 +11,16 @@ export class Video extends APIResource {
     { embeddingOption }: RetrieveVideoParams = {},
     options: RequestOptions = {},
   ): Promise<Models.Video> {
-    let queryString = '';
-
-    if (embeddingOption && embeddingOption.length > 0) {
+    let url = `indexes/${indexId}/videos/${id}`;
+    if (embeddingOption?.length) {
+      const queryParams = new URLSearchParams();
       embeddingOption.forEach(option => {
-        queryString += `embedding_option=${encodeURIComponent(option)}&`;
+        queryParams.append('embedding_option', option);
       });
-      // Remove trailing &
-      queryString = queryString.slice(0, -1);
+      url += `?${queryParams.toString()}`;
     }
-
     const res = await this._get<Models.VideoResponse>(
-      `indexes/${indexId}/videos/${id}${queryString ? '?' + queryString : ''}`,
+      url,
       {}, // Empty params since we're adding them directly to the URL
       { ...options, skipCamelKeys: ['user_metadata'] },
     );

--- a/src/resources/video/index.ts
+++ b/src/resources/video/index.ts
@@ -11,17 +11,12 @@ export class Video extends APIResource {
     { embeddingOption }: RetrieveVideoParams = {},
     options: RequestOptions = {},
   ): Promise<Models.Video> {
-    const url = new URL(`indexes/${indexId}/videos/${id}`, this.baseUrl);
-
-    if (embeddingOption?.length) {
-      embeddingOption.forEach(option => {
-        url.searchParams.append('embedding_option', option);
-      });
-    }
+    const path = `indexes/${indexId}/videos/${id}`;
+    const params = embeddingOption?.length ? { embedding_option: embeddingOption } : undefined;
 
     const res = await this._get<Models.VideoResponse>(
-      url.toString(),
-      {},
+      path,
+      params,
       { ...options, skipCamelKeys: ['user_metadata'] },
     );
     return new Models.Video(this, indexId, res);

--- a/src/resources/video/index.ts
+++ b/src/resources/video/index.ts
@@ -8,13 +8,22 @@ export class Video extends APIResource {
   async retrieve(
     indexId: string,
     id: string,
-    { embed }: RetrieveVideoParams = {},
+    { embeddingOption }: RetrieveVideoParams = {},
     options: RequestOptions = {},
   ): Promise<Models.Video> {
-    const _params = convertKeysToSnakeCase({ embed });
+    let queryString = '';
+
+    if (embeddingOption && embeddingOption.length > 0) {
+      embeddingOption.forEach(option => {
+        queryString += `embedding_option=${encodeURIComponent(option)}&`;
+      });
+      // Remove trailing &
+      queryString = queryString.slice(0, -1);
+    }
+
     const res = await this._get<Models.VideoResponse>(
-      `indexes/${indexId}/videos/${id}`,
-      removeUndefinedValues(_params),
+      `indexes/${indexId}/videos/${id}${queryString ? '?' + queryString : ''}`,
+      {}, // Empty params since we're adding them directly to the URL
       { ...options, skipCamelKeys: ['user_metadata'] },
     );
     return new Models.Video(this, indexId, res);

--- a/src/resources/video/index.ts
+++ b/src/resources/video/index.ts
@@ -11,17 +11,17 @@ export class Video extends APIResource {
     { embeddingOption }: RetrieveVideoParams = {},
     options: RequestOptions = {},
   ): Promise<Models.Video> {
-    let url = `indexes/${indexId}/videos/${id}`;
+    const url = new URL(`indexes/${indexId}/videos/${id}`, this.baseUrl);
+
     if (embeddingOption?.length) {
-      const queryParams = new URLSearchParams();
       embeddingOption.forEach(option => {
-        queryParams.append('embedding_option', option);
+        url.searchParams.append('embedding_option', option);
       });
-      url += `?${queryParams.toString()}`;
     }
+
     const res = await this._get<Models.VideoResponse>(
-      url,
-      {}, // Empty params since we're adding them directly to the URL
+      url.toString(),
+      {},
       { ...options, skipCamelKeys: ['user_metadata'] },
     );
     return new Models.Video(this, indexId, res);

--- a/src/resources/video/interfaces.ts
+++ b/src/resources/video/interfaces.ts
@@ -1,7 +1,7 @@
 import { PageOptions } from '../../interfaces';
 
 export interface RetrieveVideoParams {
-  embed?: boolean;
+  embeddingOption?: Array<'visual-text' | 'audio'>;
 }
 
 export interface ListVideoParams extends PageOptions {

--- a/src/resources/video/interfaces.ts
+++ b/src/resources/video/interfaces.ts
@@ -1,7 +1,7 @@
 import { PageOptions } from '../../interfaces';
 
 export interface RetrieveVideoParams {
-  embeddingOption?: Array<'visual-text' | 'audio'>;
+  embeddingOption?: ('visual-text' | 'audio')[];
 }
 
 export interface ListVideoParams extends PageOptions {


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

<!-- Please provide a detailed description of the pull request, including the purpose of the change, the problem it solves, or the feature it adds to the project. Ensure you link any relevant issues this PR addresses. -->

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [ ] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [ ] I have added necessary documentation (if appropriate).

## Further comments
Support multi-vector retrieval for video. 

**`embedding_option`** Specifies which types of embeddings to retrieve. You can include one or more of the following values:
  - `visual-text`:  Returns visual embeddings optimized for text search.
  - `audio`: Returns audio embeddings.
To retrieve embeddings for a video, it must be indexed using the Marengo video understanding model version 2.7 or later. For details on enabling this model for an index, see the [Create an index](/reference/create-index) page. 
        
The platform does not return embeddings if you don't provide this parameter.
        
The values you specify in `embedding_option` must be included in the `model_options` defined when the index was created. For example, if `model_options` is set to `visual,` you cannot set `embedding_option` to `audio` or  both `visual-text` and `audio`.

## Testing done 
`npx ts-node examples/embed.ts && npx ts-node examples/video.ts`