### PR TITLE
ci: fix npm publish by upgrading Node to 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Set up node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
-                  node-version: "18.18.0"
+                  node-version: "20"
 
             - name: Setup yarn
               run: npm install -g yarn
@@ -42,9 +42,9 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Set up node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
-                  node-version: "18.18.0"
+                  node-version: "20"
 
             - name: Setup yarn
               run: npm install -g yarn
@@ -67,9 +67,9 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Set up node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
-                  node-version: "18.18.0"
+                  node-version: "20"
 
             - name: Setup yarn
               run: npm install -g yarn


### PR DESCRIPTION
## Summary
- Bump `actions/setup-node` from v4 to v5 across compile/test/publish jobs
- Bump `node-version` from `18.18.0` to `20` across compile/test/publish jobs

## Why
The publish job [started failing](https://github.com/twelvelabs-io/twelvelabs-js/actions/runs/25488846045/job/74791510600) because `npx -y npm@latest publish` now pulls npm 11.x, which requires Node `^20.17.0 || >=22.9.0`. Running it on Node 18.18.0 throws:

```
npm error (0 , L.tracingChannel) is not a function
```

`tracingChannel` was added in Node 19.9.0, so the latest npm cannot run on Node 18 anymore. This wasn't an issue before because `npm@latest` previously resolved to a Node 18-compatible major.

This also resolves the `actions/setup-node@v4` Node 20 deprecation warning emitted by current GitHub Actions runners.

## Test plan
- [ ] CI compile/test jobs pass on this PR
- [ ] After merge, next tag push triggers the publish job successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)