### PR TITLE
fix: fire waitForDone callback for already-terminal tasks

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -7,5 +7,7 @@ src/wrapper
 src/index.ts
 tsconfig.json
 
+tests/custom.test.ts
+
 README.md
 .github

--- a/src/wrapper/resources/EmbedTasksWrapper.ts
+++ b/src/wrapper/resources/EmbedTasksWrapper.ts
@@ -135,11 +135,22 @@ export class EmbedTasksWrapper extends Tasks {
             throw new Error("sleepInterval must be greater than 0");
         }
 
-        // Get initial task
-        let task = await this.status(taskId, requestOptions);
-
         // Check if it's already done
         const doneStatuses = ["ready", "failed"];
+
+        // Invoke the callback for every observed status, including the initial fetch
+        const invokeCallback = async (t: TwelvelabsApi.embed.TasksStatusResponse): Promise<void> => {
+            if (callback) {
+                const result = callback(t);
+                if (result instanceof Promise) {
+                    await result;
+                }
+            }
+        };
+
+        // Get initial task and report its status (covers the already-terminal case)
+        let task = await this.status(taskId, requestOptions);
+        await invokeCallback(task);
 
         // Continue checking until it's done
         while (!task.status || doneStatuses.indexOf(task.status) === -1) {
@@ -152,12 +163,7 @@ export class EmbedTasksWrapper extends Tasks {
                 continue;
             }
 
-            if (callback) {
-                const result = callback(task);
-                if (result instanceof Promise) {
-                    await result;
-                }
-            }
+            await invokeCallback(task);
         }
 
         return task;

--- a/src/wrapper/resources/TasksWrapper.ts
+++ b/src/wrapper/resources/TasksWrapper.ts
@@ -41,7 +41,7 @@ export class TasksWrapper extends Tasks {
             videoUrls?: string[];
             enableVideoStream?: boolean;
         },
-        requestOptions?: Tasks.RequestOptions
+        requestOptions?: Tasks.RequestOptions,
     ): Promise<TwelvelabsApi.TasksCreateResponse[]> {
         const { indexId, videoFiles, videoUrls, enableVideoStream } = request;
 
@@ -60,7 +60,7 @@ export class TasksWrapper extends Tasks {
                             videoFile,
                             enableVideoStream,
                         },
-                        requestOptions
+                        requestOptions,
                     );
                     tasks.push(task);
                 } catch (e) {
@@ -79,7 +79,7 @@ export class TasksWrapper extends Tasks {
                             videoUrl,
                             enableVideoStream,
                         },
-                        requestOptions
+                        requestOptions,
                     );
                     tasks.push(task);
                 } catch (e) {
@@ -125,7 +125,7 @@ export class TasksWrapper extends Tasks {
             sleepInterval?: number;
             callback?: (task: TwelvelabsApi.TasksRetrieveResponse) => void | Promise<void>;
         },
-        requestOptions?: Tasks.RequestOptions
+        requestOptions?: Tasks.RequestOptions,
     ): Promise<TwelvelabsApi.TasksRetrieveResponse> {
         const sleepInterval = options?.sleepInterval ?? 5.0;
         const callback = options?.callback;
@@ -134,11 +134,22 @@ export class TasksWrapper extends Tasks {
             throw new Error("sleepInterval must be greater than 0");
         }
 
-        // Get initial task
-        let task = await this.retrieve(taskId, requestOptions);
-
         // Check if it's already done
         const doneStatuses = ["ready", "failed"];
+
+        // Invoke the callback for every observed status, including the initial fetch
+        const invokeCallback = async (t: TwelvelabsApi.TasksRetrieveResponse): Promise<void> => {
+            if (callback) {
+                const result = callback(t);
+                if (result instanceof Promise) {
+                    await result;
+                }
+            }
+        };
+
+        // Get initial task and report its status (covers the already-terminal case)
+        let task = await this.retrieve(taskId, requestOptions);
+        await invokeCallback(task);
 
         // Continue checking until it's done
         while (!task.status || doneStatuses.indexOf(task.status) === -1) {
@@ -151,12 +162,7 @@ export class TasksWrapper extends Tasks {
                 continue;
             }
 
-            if (callback) {
-                const result = callback(task);
-                if (result instanceof Promise) {
-                    await result;
-                }
-            }
+            await invokeCallback(task);
         }
 
         return task;

--- a/tests/custom.test.ts
+++ b/tests/custom.test.ts
@@ -6,8 +6,190 @@
  * If you include example requests/responses in your fern definition,
  * you will have tests automatically generated for you.
  */
-describe("test", () => {
-    it("default", () => {
-        expect(true).toBe(true);
+import { TasksWrapper } from "../src/wrapper/resources/TasksWrapper";
+import { EmbedTasksWrapper } from "../src/wrapper/resources/EmbedTasksWrapper";
+import * as TwelvelabsApi from "../src/api";
+
+const makeIndexingTask = (
+    status: string,
+    overrides: Partial<TwelvelabsApi.TasksRetrieveResponse> = {},
+): TwelvelabsApi.TasksRetrieveResponse => ({
+    id: "task_123",
+    status,
+    ...overrides,
+});
+
+const makeEmbedStatus = (
+    status: string,
+    overrides: Partial<TwelvelabsApi.embed.TasksStatusResponse> = {},
+): TwelvelabsApi.embed.TasksStatusResponse => ({
+    id: "embed_task_123",
+    status,
+    ...overrides,
+});
+
+describe("TasksWrapper.waitForDone", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+        jest.useRealTimers();
+    });
+
+    // Regression (QA-3371): a task that is already terminal at entry must still
+    // fire the callback exactly once. `retrieve` being called exactly once proves
+    // the polling loop body — and therefore its `setTimeout` sleep — never ran.
+    it("fires the callback once for a task that is already ready at entry", async () => {
+        const wrapper = new TasksWrapper({ apiKey: "test-api-key" });
+        const retrieveSpy = jest.spyOn(wrapper, "retrieve").mockResolvedValueOnce(makeIndexingTask("ready"));
+        const callback = jest.fn();
+
+        const result = await wrapper.waitForDone("task_123", { callback });
+
+        expect(retrieveSpy).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith(expect.objectContaining({ status: "ready" }));
+        expect(result.status).toBe("ready");
+    });
+
+    it("fires the callback once for a task that is already failed at entry", async () => {
+        const wrapper = new TasksWrapper({ apiKey: "test-api-key" });
+        const retrieveSpy = jest.spyOn(wrapper, "retrieve").mockResolvedValueOnce(makeIndexingTask("failed"));
+        const callback = jest.fn();
+
+        const result = await wrapper.waitForDone("task_123", { callback });
+
+        expect(retrieveSpy).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith(expect.objectContaining({ status: "failed" }));
+        expect(result.status).toBe("failed");
+    });
+
+    it("invokes the callback for each observed status, including the initial and terminal ones", async () => {
+        jest.useFakeTimers();
+        const wrapper = new TasksWrapper({ apiKey: "test-api-key" });
+        const retrieveSpy = jest
+            .spyOn(wrapper, "retrieve")
+            .mockResolvedValueOnce(makeIndexingTask("pending"))
+            .mockResolvedValueOnce(makeIndexingTask("indexing"))
+            .mockResolvedValueOnce(makeIndexingTask("ready"));
+        const observed: string[] = [];
+
+        const promise = wrapper.waitForDone("task_123", {
+            sleepInterval: 5,
+            callback: (task) => {
+                observed.push(task.status!);
+            },
+        });
+        await jest.runAllTimersAsync();
+        const result = await promise;
+
+        expect(retrieveSpy).toHaveBeenCalledTimes(3);
+        expect(observed).toEqual(["pending", "indexing", "ready"]);
+        expect(result.status).toBe("ready");
+    });
+
+    it("resolves without throwing when no callback is provided and the task is already ready", async () => {
+        const wrapper = new TasksWrapper({ apiKey: "test-api-key" });
+        jest.spyOn(wrapper, "retrieve").mockResolvedValueOnce(makeIndexingTask("ready"));
+
+        await expect(wrapper.waitForDone("task_123")).resolves.toEqual(expect.objectContaining({ status: "ready" }));
+    });
+
+    it("awaits an async callback before resolving", async () => {
+        const wrapper = new TasksWrapper({ apiKey: "test-api-key" });
+        jest.spyOn(wrapper, "retrieve").mockResolvedValueOnce(makeIndexingTask("ready"));
+        const order: string[] = [];
+        const callback = jest.fn(async () => {
+            // Defer the side effect by a microtask so the ordering only holds if
+            // `waitForDone` actually awaits the returned promise.
+            await Promise.resolve();
+            order.push("callback");
+        });
+
+        await wrapper.waitForDone("task_123", { callback });
+        order.push("after-await");
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(order).toEqual(["callback", "after-await"]);
+    });
+});
+
+describe("EmbedTasksWrapper.waitForDone", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+        jest.useRealTimers();
+    });
+
+    it("fires the callback once for a task that is already ready at entry", async () => {
+        const wrapper = new EmbedTasksWrapper({ apiKey: "test-api-key" });
+        const statusSpy = jest.spyOn(wrapper, "status").mockResolvedValueOnce(makeEmbedStatus("ready"));
+        const callback = jest.fn();
+
+        const result = await wrapper.waitForDone("embed_task_123", { callback });
+
+        expect(statusSpy).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith(expect.objectContaining({ status: "ready" }));
+        expect(result.status).toBe("ready");
+    });
+
+    it("fires the callback once for a task that is already failed at entry", async () => {
+        const wrapper = new EmbedTasksWrapper({ apiKey: "test-api-key" });
+        const statusSpy = jest.spyOn(wrapper, "status").mockResolvedValueOnce(makeEmbedStatus("failed"));
+        const callback = jest.fn();
+
+        const result = await wrapper.waitForDone("embed_task_123", { callback });
+
+        expect(statusSpy).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith(expect.objectContaining({ status: "failed" }));
+        expect(result.status).toBe("failed");
+    });
+
+    it("invokes the callback for each observed status, including the initial and terminal ones", async () => {
+        jest.useFakeTimers();
+        const wrapper = new EmbedTasksWrapper({ apiKey: "test-api-key" });
+        const statusSpy = jest
+            .spyOn(wrapper, "status")
+            .mockResolvedValueOnce(makeEmbedStatus("processing"))
+            .mockResolvedValueOnce(makeEmbedStatus("ready"));
+        const observed: string[] = [];
+
+        const promise = wrapper.waitForDone("embed_task_123", {
+            sleepInterval: 5,
+            callback: (task) => {
+                observed.push(task.status!);
+            },
+        });
+        await jest.runAllTimersAsync();
+        const result = await promise;
+
+        expect(statusSpy).toHaveBeenCalledTimes(2);
+        expect(observed).toEqual(["processing", "ready"]);
+        expect(result.status).toBe("ready");
+    });
+
+    it("resolves without throwing when no callback is provided and the task is already ready", async () => {
+        const wrapper = new EmbedTasksWrapper({ apiKey: "test-api-key" });
+        jest.spyOn(wrapper, "status").mockResolvedValueOnce(makeEmbedStatus("ready"));
+
+        await expect(wrapper.waitForDone("embed_task_123")).resolves.toEqual(
+            expect.objectContaining({ status: "ready" }),
+        );
+    });
+
+    it("awaits an async callback before resolving", async () => {
+        const wrapper = new EmbedTasksWrapper({ apiKey: "test-api-key" });
+        jest.spyOn(wrapper, "status").mockResolvedValueOnce(makeEmbedStatus("ready"));
+        const order: string[] = [];
+        const callback = jest.fn(async () => {
+            await Promise.resolve();
+            order.push("callback");
+        });
+
+        await wrapper.waitForDone("embed_task_123", { callback });
+        order.push("after-await");
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(order).toEqual(["callback", "after-await"]);
     });
 });


### PR DESCRIPTION
## SDK wait-for-done callback not fired when task is already ready

### Problem
`waitForDone` polls a task's status and invokes the caller-supplied `callback` on each poll until the task reaches a terminal state (`ready`/`failed`). Callback invocation was coupled to the polling `while` loop body, so:

- when a task is **already terminal at entry**, the loop never runs and the `callback` is **never fired**;
- the **initial** observed status of in-progress tasks was also never delivered (the callback only started firing after the first sleep + re-fetch).

### Fix
In both hand-written, `.fernignore`-protected wrappers (`TasksWrapper`, `EmbedTasksWrapper`), extract a small `invokeCallback` helper and call it **once immediately after the initial fetch**, then on every poll. The existing sync/async handling (`result instanceof Promise` → `await`) is preserved.

No changes to public signatures, the default `sleepInterval`, the `sleepInterval <= 0` validation, the retry `console.error`/`continue` path, or `doneStatuses`.

### Tests
Added 10 tests (5 per wrapper) in `tests/custom.test.ts` (now listed in `.fernignore` so a future Fern regeneration won't drop them):

1. **Already `ready` at entry** (the regression) → `callback` fires exactly once; `retrieve`/`status` called exactly once (proving no poll/sleep ran).
2. **Already `failed` at entry** → `callback` fires once.
3. **Progress sequence** → `callback` fires for each observed status in order, including initial and terminal (fake timers).
4. **No callback provided** → resolves cleanly.
5. **Async callback** → awaited before `waitForDone` resolves (ordering assertion).

### Verification
- `yarn build` (tsc) ✅
- `yarn test` → **270 passed / 41 suites** ✅
- `prettier --check` on changed files ✅

> Note: `TasksWrapper.ts` also picked up 4 pre-existing trailing-comma normalizations from `prettier` (the file already failed `prettier --check` on `main`); they match the sibling `EmbedTasksWrapper.ts` style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)